### PR TITLE
Apply CMake policy CMP0072 only when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,10 @@ set_target_properties( ${PROJECT_NAME}
 	DEBUG_POSTFIX "_d"
 )
 
-cmake_policy(SET CMP0072 NEW)
+if (POLICY CMP0072)
+       cmake_policy(SET CMP0072 NEW)
+endif()
+
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME} ${OPENGL_LIBRARIES})


### PR DESCRIPTION
CMP0072 policy introduced in commit e5d60cb requires CMake >= 3.11