### PR TITLE
New keyboard shortcut for taking screenshots.

### DIFF
--- a/drivermode.cpp
+++ b/drivermode.cpp
@@ -866,6 +866,12 @@ driver_mode::OnKeyDown(int cKey) {
             }
             break;
         }
+        case GLFW_KEY_F12: {
+          if ((Global.shiftState == true) && (Global.ctrlState == false)) {
+	    Application.queue_screenshot();
+	    break;
+	  }
+	}
         default: {
             break;
         }

--- a/uilayer.cpp
+++ b/uilayer.cpp
@@ -272,11 +272,6 @@ bool ui_layer::on_key(int const Key, int const Action)
 {
     if (Action == GLFW_PRESS)
     {
-        if (Key == GLFW_KEY_PRINT_SCREEN) {
-            Application.queue_screenshot();
-            return true;
-        }
-
         if (Key == GLFW_KEY_F9) {
             m_logpanel.is_open = !m_logpanel.is_open;
             return true;


### PR DESCRIPTION
Due to the problems of users with saving a screenshot to a file via the `PrintScreen` key on Linux and Windows, I suggest that you set up a new hotkey -` Shift` + `F12`.

The previous key does not save screenshots (on XFCE it is captured by the built-in screenshot program, on Windows some also had problems (I don't know about Windows)).