### PR TITLE
New keyboard shortcut for taking screenshots.

### DIFF
--- a/command.cpp
+++ b/command.cpp
@@ -344,6 +344,7 @@ commanddescription_sequence Commands_descriptions = {
     { "spawntrainset", command_target::simulation, command_mode::oneoff },
     { "destroytrainset", command_target::simulation, command_mode::oneoff },
     { "quitsimulation", command_target::simulation, command_mode::oneoff },
+    { "screenshot", command_target::simulation, command_mode::oneoff },
 };
 
 } // simulation

--- a/command.h
+++ b/command.h
@@ -339,6 +339,7 @@ enum class user_command {
     spawntrainset,
     destroytrainset,
     quitsimulation,
+    screenshot,
 
     none = -1
 };

--- a/driverkeyboardinput.cpp
+++ b/driverkeyboardinput.cpp
@@ -289,7 +289,8 @@ driverkeyboard_input::default_bindings() {
 	    { user_command::vehiclemovebackwards, GLFW_KEY_RIGHT_BRACKET | keymodifier::control },
 	    { user_command::vehicleboost, GLFW_KEY_TAB | keymodifier::control },
 	    { user_command::debugtoggle, GLFW_KEY_F12 | keymodifier::control | keymodifier::shift },
-	    { user_command::pausetoggle, GLFW_KEY_ESCAPE }
+	    { user_command::pausetoggle, GLFW_KEY_ESCAPE },
+	    { user_command::screenshot, GLFW_KEY_F12 | keymodifier::shift }
     };
 }
 

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -478,6 +478,9 @@ void state_manager::process_commands() {
 			}
 		}
 	}
+	if (commanddata.command == user_command::screenshot && commanddata.action == GLFW_PRESS) {
+		Application.queue_screenshot();
+	}
 }
 
 TAnimModel * state_manager::create_model(const std::string &src, const std::string &name, const glm::dvec3 &position) {


### PR DESCRIPTION
Due to users' problems with saving the screenshot to file via the `PrintScreen` key on Linux and Windows systems, I propose to set up a new keyboard shortcut -` Shift` + `F12` with the possibility to change it via the file` eu07_input-keyboard.ini`.

The previous key does not save screenshots (on XFCE it is captured by the built-in screenshot program, on Windows some also had problems (I don't know about Windows))

Add to `eu07_input-keyboard.ini`:
```
screenshot shift F12 // zrzut ekranu
```