### PR TITLE
Fixed problem with PYTHONHOME on Linux // Problem z ustawieniem PYTHONHOME na Linuxie

### DIFF
--- a/PyInt.cpp
+++ b/PyInt.cpp
@@ -155,11 +155,6 @@ auto python_taskqueue::init() -> bool {
 		Py_SetPythonHome("python64");
 	else
 		Py_SetPythonHome("python");
-#elif __linux__
-	if (sizeof(void*) == 8)
-		Py_SetPythonHome("linuxpython64");
-	else
-		Py_SetPythonHome("linuxpython");
 #elif __APPLE__
 	if (sizeof(void*) == 8)
 		Py_SetPythonHome("macpython64");


### PR DESCRIPTION
Ten fix naprawia problem z szukaniem bibliotek dla Pythona na Linuxie. Z tą zmianą Python szuka bibliotek w systemie i ewentualne biblioteki trzeba zainstalować pipem. Informacyjnie maszyna używa pythona2.