### PR TITLE
Fixes for timetable window width and tiny launcher adjustments

### DIFF
--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -485,11 +485,13 @@ timetable_panel::render() {
         | ImGuiWindowFlags_NoCollapse
         | ( size.x > 0 ? ImGuiWindowFlags_NoResize : 0 );
 
+    // HACK: Make sure the timetable window is of correct width when using a larger font size.
+    float horizontalScale = Global.ui_fontsize / 13;
     if( size.x > 0 ) {
-        ImGui::SetNextWindowSize( ImVec2S( size.x, size.y ) );
+        ImGui::SetNextWindowSize( ImVec2S( size.x * horizontalScale, size.y ) );
     }
     if( size_min.x > 0 ) {
-        ImGui::SetNextWindowSizeConstraints( ImVec2S( size_min.x, size_min.y ), ImVec2S( size_max.x, size_max.y ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2S( size_min.x * horizontalScale, size_min.y ), ImVec2S( size_max.x * horizontalScale, size_max.y ) );
     }
     auto const panelname { (
         title.empty() ?

--- a/keyboardinput.cpp
+++ b/keyboardinput.cpp
@@ -173,7 +173,6 @@ keyboard_input::recall_bindings() {
                     // This can't be done now as by default this would destroy all command descriptions,
                     // which are used by Starter.
                     // Do this when szczawik's Starter becomes deprecated or implements command descriptions in some other way.
-                    WriteLog("got: \"" + bindingkeyname + "\"");
                     if (descriptionStarted) {
                         if (description.size() > 0) {
                             description += " ";

--- a/launcher/vehicle_picker.h
+++ b/launcher/vehicle_picker.h
@@ -19,7 +19,7 @@ private:
 	std::shared_ptr<const vehicle_desc> selected_vehicle;
 	const std::string *selected_group = nullptr;
 	const skin_set *selected_skinset = nullptr;
-	bool display_by_groups = false;
+	bool display_by_groups = true;
 	deferred_image placeholder_mini;
 	std::array<char, 128> search_query = { 0 };
 


### PR DESCRIPTION
Fixes #64 by adjusting the timetable window width proportionally to the font size.