### PR TITLE
Add missing asio ref & add power usage variables to python dict

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ref/asio"]
+	path = ref/asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/Train.cpp
+++ b/Train.cpp
@@ -743,6 +743,9 @@ dictionary_source *TTrain::GetTrainState( dictionary_source const &Extraparamete
     dict->insert( "im", std::abs(  mvControlled->Im ) );
     dict->insert( "fuse", mvControlled->FuseFlag );
     dict->insert( "epfuse", mvOccupied->EpFuse );
+	dict->insert( "power_drawn", mvOccupied->EnergyMeter.first);
+	dict->insert( "power_returned", mvOccupied->EnergyMeter.second);
+
     // induction motor state data
     char const *TXTT[ 10 ] = { "fd", "fdt", "fdb", "pd", "pdt", "pdb", "itothv", "1", "2", "3" };
     char const *TXTC[ 10 ] = { "fr", "frt", "frb", "pr", "prt", "prb", "im", "vm", "ihv", "uhv" };


### PR DESCRIPTION
Add asio ref required for cmake ..\ and add two variables to state dict in python: power_drawn & power_returned (both double)