### PR TITLE
Fiz parameters to hide direction lights when moving

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ref/asio"]
+	path = ref/asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1196,6 +1196,7 @@ public:
 	bool ReleaseParkingBySpringBrakeWhenDoorIsOpen{ false };
 	bool SpringBrakeCutsOffDrive { true };
 	double SpringBrakeDriveEmergencyVel { -1 };
+	bool HideDirStatusWhenMoving { false };
 	TSecuritySystem SecuritySystem;
     int EmergencyBrakeWarningSignal{ 0 }; // combined with basic WarningSignal when manual emergency brake is active
 	TUniversalCtrlTable UniCtrlList;     /*lista pozycji uniwersalnego nastawnika*/

--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1196,7 +1196,8 @@ public:
 	bool ReleaseParkingBySpringBrakeWhenDoorIsOpen{ false };
 	bool SpringBrakeCutsOffDrive { true };
 	double SpringBrakeDriveEmergencyVel { -1 };
-	bool HideDirStatusWhenMoving { false };
+	bool HideDirStatusWhenMoving { false }; // Czy gasic lampki kierunku powyzej predkosci zdefiniowanej przez HideDirStatusSpeed
+	int HideDirStatusSpeed{ 1 };	// Predkosc od ktorej lampki kierunku sa wylaczane
 	TSecuritySystem SecuritySystem;
     int EmergencyBrakeWarningSignal{ 0 }; // combined with basic WarningSignal when manual emergency brake is active
 	TUniversalCtrlTable UniCtrlList;     /*lista pozycji uniwersalnego nastawnika*/

--- a/McZapkie/Mover.cpp
+++ b/McZapkie/Mover.cpp
@@ -10576,6 +10576,7 @@ void TMoverParameters::LoadFIZ_Cntrl( std::string const &line ) {
 	extract_value( SpringBrakeCutsOffDrive, "SpringBrakeCutsOffDrive", line, "");
 	extract_value( SpringBrakeDriveEmergencyVel, "SpringBrakeDriveEmergencyVel", line, "");
 
+    extract_value(HideDirStatusWhenMoving "HideDirStatusWhenMoving", line, "");
     std::map<std::string, start_t> starts {
         { "Disabled", start_t::disabled },
         { "Manual", start_t::manual },

--- a/McZapkie/Mover.cpp
+++ b/McZapkie/Mover.cpp
@@ -10576,7 +10576,9 @@ void TMoverParameters::LoadFIZ_Cntrl( std::string const &line ) {
 	extract_value( SpringBrakeCutsOffDrive, "SpringBrakeCutsOffDrive", line, "");
 	extract_value( SpringBrakeDriveEmergencyVel, "SpringBrakeDriveEmergencyVel", line, "");
 
-    extract_value(HideDirStatusWhenMoving "HideDirStatusWhenMoving", line, "");
+    extract_value(HideDirStatusWhenMoving, "HideDirStatusWhenMoving", line, "");
+	extract_value(HideDirStatusSpeed, "HideDirStatusSpeed", line, "");
+
     std::map<std::string, start_t> starts {
         { "Disabled", start_t::disabled },
         { "Manual", start_t::manual },

--- a/Train.cpp
+++ b/Train.cpp
@@ -743,6 +743,9 @@ dictionary_source *TTrain::GetTrainState( dictionary_source const &Extraparamete
     dict->insert( "im", std::abs(  mvControlled->Im ) );
     dict->insert( "fuse", mvControlled->FuseFlag );
     dict->insert( "epfuse", mvOccupied->EpFuse );
+	dict->insert( "power_drawn", mvOccupied->EnergyMeter.first);
+	dict->insert( "power_returned", mvOccupied->EnergyMeter.second);
+
     // induction motor state data
     char const *TXTT[ 10 ] = { "fd", "fdt", "fdb", "pd", "pdt", "pdb", "itothv", "1", "2", "3" };
     char const *TXTC[ 10 ] = { "fr", "frt", "frb", "pr", "prt", "prb", "im", "vm", "ihv", "uhv" };

--- a/Train.cpp
+++ b/Train.cpp
@@ -7537,6 +7537,7 @@ bool TTrain::Update( double const Deltatime )
         btLampkaDoorLockOff.Turn( false == mvOccupied->Doors.lock_enabled );
         btLampkaDepartureSignal.Turn( mvControlled->DepartureSignal );
         btLampkaNapNastHam.Turn((mvControlled->DirActive != 0) && (mvOccupied->EpFuse)); // napiecie na nastawniku hamulcowym
+        
         // Wylaczanie lampek kierunku gdy jedziemy
         // Feature uruchamiany z fiz z sekcji Ctrl. wpisem HideDirStatusWhenMoving=Yes (domyslnie No)
 		if (mvOccupied->HideDirStatusWhenMoving && // Czy ta funkcja jest w ogole wlaczona
@@ -7549,6 +7550,7 @@ bool TTrain::Update( double const Deltatime )
 			btLampkaForward.Turn(mvControlled->DirActive > 0); // jazda do przodu
 			btLampkaBackward.Turn(mvControlled->DirActive < 0); // jazda do tyłu
         }
+
         btLampkaED.Turn(mvControlled->DynamicBrakeFlag); // hamulec ED
         btLampkaBrakeProfileG.Turn( TestFlag( mvOccupied->BrakeDelayFlag, bdelay_G ) );
         btLampkaBrakeProfileP.Turn( TestFlag( mvOccupied->BrakeDelayFlag, bdelay_P ) );

--- a/Train.cpp
+++ b/Train.cpp
@@ -7539,7 +7539,9 @@ bool TTrain::Update( double const Deltatime )
         btLampkaNapNastHam.Turn((mvControlled->DirActive != 0) && (mvOccupied->EpFuse)); // napiecie na nastawniku hamulcowym
         // Wylaczanie lampek kierunku gdy jedziemy
         // Feature uruchamiany z fiz z sekcji Ctrl. wpisem HideDirStatusWhenMoving=Yes (domyslnie No)
-        if (mvOccupied->HideDirStatusWhenMoving && mvOccupied->Vel > 1) {   
+		if (mvOccupied->HideDirStatusWhenMoving && // Czy ta funkcja jest w ogole wlaczona
+            mvOccupied->Vel > mvOccupied->HideDirStatusSpeed) // Uzaleznienie od predkosci
+		{   
             btLampkaForward.Turn(false);
 			btLampkaBackward.Turn(false);
         }

--- a/Train.cpp
+++ b/Train.cpp
@@ -7537,8 +7537,16 @@ bool TTrain::Update( double const Deltatime )
         btLampkaDoorLockOff.Turn( false == mvOccupied->Doors.lock_enabled );
         btLampkaDepartureSignal.Turn( mvControlled->DepartureSignal );
         btLampkaNapNastHam.Turn((mvControlled->DirActive != 0) && (mvOccupied->EpFuse)); // napiecie na nastawniku hamulcowym
-        btLampkaForward.Turn(mvControlled->DirActive > 0); // jazda do przodu
-        btLampkaBackward.Turn(mvControlled->DirActive < 0); // jazda do tyłu
+        // Wylaczanie lampek kierunku gdy jedziemy
+        // Feature uruchamiany z fiz z sekcji Ctrl. wpisem HideDirStatusWhenMoving=Yes (domyslnie No)
+        if (mvOccupied->HideDirStatusWhenMoving && mvOccupied->Vel > 1) {   
+            btLampkaForward.Turn(false);
+			btLampkaBackward.Turn(false);
+        }
+        else {
+			btLampkaForward.Turn(mvControlled->DirActive > 0); // jazda do przodu
+			btLampkaBackward.Turn(mvControlled->DirActive < 0); // jazda do tyłu
+        }
         btLampkaED.Turn(mvControlled->DynamicBrakeFlag); // hamulec ED
         btLampkaBrakeProfileG.Turn( TestFlag( mvOccupied->BrakeDelayFlag, bdelay_G ) );
         btLampkaBrakeProfileP.Turn( TestFlag( mvOccupied->BrakeDelayFlag, bdelay_P ) );


### PR DESCRIPTION
Both parameters are in `Cntrl.` section
- `HideDirStatusWhenMoving=[No]` - (Yes/No) - Enable turning off direction lights
- `HideDirStatusSpeed=[1]` - Speed in km/h above which lights should be turned off