### PR TITLE
Cab resonance & wind sound

### DIFF
--- a/McZapkie/MOVER.h
+++ b/McZapkie/MOVER.h
@@ -1418,7 +1418,7 @@ public:
     double AccSVBased {}; // tangential acceleration calculated from velocity change
 	double AccN = 0.0; // przyspieszenie normalne w [m/s^2]
 	double AccVert = 0.0; // vertical acceleration
-	double nrot = 0.0;
+	double nrot = 0.0;	// predkosc obrotowa kol (obrotow na sekunde)
 	double nrot_eps = 0.0; //przyspieszenie kątowe kół (bez kierunku)
 	double WheelFlat = 0.0;
     bool TruckHunting { true }; // enable/disable truck hunting calculation

--- a/Train.cpp
+++ b/Train.cpp
@@ -8312,6 +8312,16 @@ TTrain::update_sounds( double const Deltatime ) {
         }
     }
 
+    // dzwiek wiatru rozbijajacego sie o szyby w kabinie
+    if (rsWindSound) 
+    {
+		if (!FreeFlyModeFlag && !Global.CabWindowOpen && DynamicObject->GetVelocity() > 0.5)
+            update_sounds_resonancenoise(*rsWindSound);
+        else
+			rsWindSound->stop(FreeFlyModeFlag);
+    }
+
+
     // dzwiek rezonansu (taki drugi runningnoise w sumie)
 	if (rsResonanceNoise)
     {

--- a/Train.cpp
+++ b/Train.cpp
@@ -8311,6 +8311,20 @@ TTrain::update_sounds( double const Deltatime ) {
             dsbSlipAlarm->stop();
         }
     }
+
+    // dzwiek rezonansu (taki drugi runningnoise w sumie)
+	if (rsResonanceNoise)
+    {
+		if (!FreeFlyModeFlag && !Global.CabWindowOpen && DynamicObject->GetVelocity() > 0.5)
+		{
+
+			update_sounds_resonancenoise(*rsResonanceNoise);
+		}
+		else
+			rsResonanceNoise->stop(FreeFlyModeFlag);
+    }
+
+
     // szum w czasie jazdy
     if( rsRunningNoise ) {
         if( ( false == FreeFlyModeFlag )
@@ -8454,6 +8468,25 @@ TTrain::update_sounds( double const Deltatime ) {
     }
 
     update_sounds_radio();
+}
+
+void TTrain::update_sounds_resonancenoise(sound_source &Sound)
+{
+	// frequency calculation
+	auto const normalizer{mvOccupied->Vmax * 0.01f};
+	auto const frequency{Sound.m_frequencyoffset + Sound.m_frequencyfactor * mvOccupied->Vel * normalizer};
+
+	// volume calculation
+	auto volume = Sound.m_amplitudeoffset + Sound.m_amplitudefactor * interpolate(mvOccupied->Vel / (1 + mvOccupied->Vmax), 1.0, 0.5); // scale base volume between 0.5-1.0
+
+	if (volume > 0.05)
+	{
+		Sound.pitch(frequency).gain(volume).play(sound_flags::exclusive | sound_flags::looping);
+	}
+	else
+	{
+		Sound.stop();
+	}
 }
 
 void TTrain::update_sounds_runningnoise( sound_source &Sound ) {
@@ -8635,6 +8668,8 @@ bool TTrain::LoadMMediaFile(std::string const &asFileName)
             {"brakesound:", {rsBrake, sound_placement::internal, -1, sound_type::single, sound_parameters::amplitude | sound_parameters::frequency, 100.0}},
             {"fadesound:", {rsFadeSound, sound_placement::internal, EU07_SOUND_CABCONTROLSCUTOFFRANGE, sound_type::single, 0, 100.0}},
             {"runningnoise:", {rsRunningNoise, sound_placement::internal, EU07_SOUND_GLOBALRANGE, sound_type::single, sound_parameters::amplitude | sound_parameters::frequency, mvOccupied->Vmax }},
+            {"resonancenoise:", {rsResonanceNoise, sound_placement::internal, EU07_SOUND_GLOBALRANGE, sound_type::single, sound_parameters::amplitude | sound_parameters::frequency, mvOccupied->Vmax }},
+            {"windsound:", {rsWindSound, sound_placement::internal, EU07_SOUND_GLOBALRANGE, sound_type::single, sound_parameters::amplitude | sound_parameters::frequency, mvOccupied->Vmax }},
             {"huntingnoise:", {rsHuntingNoise, sound_placement::internal, EU07_SOUND_GLOBALRANGE, sound_type::single, sound_parameters::amplitude | sound_parameters::frequency, mvOccupied->Vmax }},
             {"rainsound:", {m_rainsound, sound_placement::internal, -1, sound_type::single, 0, 100.0}},
         };
@@ -8698,6 +8733,12 @@ bool TTrain::LoadMMediaFile(std::string const &asFileName)
         if (rsBrake) {
             rsBrake->m_frequencyfactor /= (1 + mvOccupied->Vmax);
         }
+        if (rsResonanceNoise) {
+			rsResonanceNoise->m_frequencyfactor /= (1 + mvOccupied->Vmax);
+        }
+        if (rsWindSound) {
+			rsWindSound->m_frequencyfactor /= (1 + mvOccupied->Vmax);
+        }
         if (rsRunningNoise) {
             rsRunningNoise->m_frequencyfactor /= (1 + mvOccupied->Vmax);
         }
@@ -8710,7 +8751,7 @@ bool TTrain::LoadMMediaFile(std::string const &asFileName)
 		dsbReverserKey, dsbNastawnikJazdy, dsbNastawnikBocz,
 		dsbSwitch, dsbPneumaticSwitch,
 		rsHiss, rsHissU, rsHissE, rsHissX, rsHissT, rsSBHiss, rsSBHissU,
-		rsFadeSound, rsRunningNoise, rsHuntingNoise,
+		rsFadeSound, rsRunningNoise, rsResonanceNoise,rsWindSound, rsHuntingNoise,
 		dsbHasler, dsbBuzzer,dsbBuzzerShp, dsbSlipAlarm, m_distancecounterclear, m_rainsound, m_radiostop
 	};
 	for (auto &sound : sounds) {
@@ -8733,7 +8774,7 @@ bool TTrain::InitializeCab(int NewCabNo, std::string const &asFileName)
         dsbReverserKey, dsbNastawnikJazdy, dsbNastawnikBocz,
         dsbSwitch, dsbPneumaticSwitch,
         rsHiss, rsHissU, rsHissE, rsHissX, rsHissT, rsSBHiss, rsSBHissU,
-        rsFadeSound, rsRunningNoise, rsHuntingNoise,
+        rsFadeSound, rsRunningNoise, rsResonanceNoise, rsWindSound, rsHuntingNoise,
         dsbHasler, dsbBuzzer, dsbBuzzerShp, dsbSlipAlarm, m_distancecounterclear, m_rainsound, m_radiostop
     };
     for( auto &sound : sounds ) {
@@ -9025,6 +9066,8 @@ bool TTrain::InitializeCab(int NewCabNo, std::string const &asFileName)
                 {rsSBHissU, ggBrakeCtrl.model_offset()}, // NOTE: fallback if the local brake model can't be located
                 {rsFadeSound, caboffset},
                 {rsRunningNoise, caboffset},
+                {rsResonanceNoise, caboffset},
+	            {rsWindSound, caboffset},
                 {rsHuntingNoise, caboffset},
                 {dsbHasler, caboffset},
                 {dsbBuzzer, btLampkaCzuwaka.model_offset()},

--- a/Train.h
+++ b/Train.h
@@ -210,6 +210,7 @@ class TTrain {
     // update function subroutines
     void update_sounds( double const Deltatime );
     void update_sounds_runningnoise( sound_source &Sound );
+    void update_sounds_resonancenoise( sound_source &Sound );
     void update_sounds_radio();
     inline
     end cab_to_end( int const End ) const {
@@ -804,6 +805,7 @@ public: // reszta może by?publiczna
         rsBrake,
         rsFadeSound,
         rsRunningNoise,
+        rsResonanceNoise,
         rsHuntingNoise,
         m_rainsound;
     sound_source m_radiosound { sound_placement::internal, 2 * EU07_SOUND_CABCONTROLSCUTOFFRANGE }; // cached template for radio messages

--- a/Train.h
+++ b/Train.h
@@ -805,7 +805,8 @@ public: // reszta może by?publiczna
         rsBrake,
         rsFadeSound,
         rsRunningNoise,
-        rsResonanceNoise,
+        rsResonanceNoise, 
+        rsWindSound,
         rsHuntingNoise,
         m_rainsound;
     sound_source m_radiosound { sound_placement::internal, 2 * EU07_SOUND_CABCONTROLSCUTOFFRANGE }; // cached template for radio messages


### PR DESCRIPTION
MMD:
internaldata:
windsound: 
resonancenoise:

oba definijemy tak jak runningnoise zlozone z wielu dzwiekow. Dla pojedynczego dzwieku nie dziala.

Przykład:
```
resonancenoise: { 
 crossfade: 80 
 range: -1
 amplitudefactor: 1.0
 amplitudeoffset: 0.0
 frequencyfactor: 1.0
 frequencyoffset: 0.0
 sound107: silence1.wav pitch107: 1
 sound109: CabVibrations.wav pitch109: 1
 sound111: CabVibrations.wav pitch111: 1
 sound115: silence1.wav pitch115: 1
}
```
gdzie liczba przy sound to predkosc