### PR TITLE
Add possibility for static models to have season-dependent variants

### DIFF
--- a/AnimModel.cpp
+++ b/AnimModel.cpp
@@ -318,6 +318,10 @@ bool TAnimModel::Load(cParser *parser, bool ter)
         LightsOff[5] = pModel->GetFromName("Light_Off05");
         LightsOff[6] = pModel->GetFromName("Light_Off06");
         LightsOff[7] = pModel->GetFromName("Light_Off07");
+		sm_winter_variant = pModel->GetFromName("winter_variant");
+		sm_spring_variant = pModel->GetFromName("spring_variant");
+		sm_summer_variant = pModel->GetFromName("summer_variant");
+		sm_autumn_variant = pModel->GetFromName("autumn_variant");
     }
     for (int i = 0; i < iMaxNumLights; ++i)
         if (LightsOn[i] || LightsOff[i]) // Ra: zlikwidowałem wymóg istnienia obu
@@ -494,9 +498,59 @@ void TAnimModel::RaAnimate( unsigned int const Framestamp ) {
     m_framestamp = Framestamp;
 }
 
+// aktualizujemy submodele w zaleznosci od aktualnej porty roku
+void TAnimModel::on_season_update() {
+    if (Global.Season == "winter:") // pokazujemy wariant zimowy
+    {
+		if (this->sm_winter_variant != nullptr)
+			this->sm_winter_variant->SetVisibilityLevel(1.f, true, false);
+		if (this->sm_spring_variant != nullptr)
+			this->sm_spring_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_summer_variant != nullptr)
+			this->sm_summer_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_autumn_variant != nullptr)
+			this->sm_autumn_variant->SetVisibilityLevel(0.f, true, false);
+    }
+	else if (Global.Season == "spring:") // pokazujemy wariant wiosenny
+	{
+		if (this->sm_winter_variant != nullptr)
+			this->sm_winter_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_spring_variant != nullptr)
+			this->sm_spring_variant->SetVisibilityLevel(1.f, true, false);
+		if (this->sm_summer_variant != nullptr)
+			this->sm_summer_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_autumn_variant != nullptr)
+			this->sm_autumn_variant->SetVisibilityLevel(0.f, true, false);
+    }
+    else if (Global.Season == "summer:") // pokazujemy wariant letni
+	{
+		if (this->sm_winter_variant != nullptr)
+			this->sm_winter_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_spring_variant != nullptr)
+			this->sm_spring_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_summer_variant != nullptr)
+			this->sm_summer_variant->SetVisibilityLevel(1.f, true, false);
+		if (this->sm_autumn_variant != nullptr)
+			this->sm_autumn_variant->SetVisibilityLevel(0.f, true, false);
+    }
+	else if (Global.Season == "autumn:") // pokazujemy wariant jesienny
+    {
+		if (this->sm_winter_variant != nullptr) 
+            this->sm_winter_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_spring_variant != nullptr) 
+		    this->sm_spring_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_summer_variant != nullptr) 
+		    this->sm_summer_variant->SetVisibilityLevel(0.f, true, false);
+		if (this->sm_autumn_variant != nullptr) 
+		    this->sm_autumn_variant->SetVisibilityLevel(1.f, true, false);
+    }
+}
+
 void TAnimModel::RaPrepare()
 { // ustawia światła i animacje we wzorcu modelu przed renderowaniem egzemplarza
     bool state; // stan światła
+	if (Global.UpdateMaterials)
+	    on_season_update();
     for (int i = 0; i < iNumLights; ++i)
     {
         auto const lightmode { static_cast<int>( std::abs( lsLights[ i ] ) ) };

--- a/AnimModel.h
+++ b/AnimModel.h
@@ -25,12 +25,14 @@ const int iMaxNumLights = 8;
 float const DefaultDarkThresholdLevel { 0.325f };
 
 // typy stanu świateł
-enum TLightState {
-    ls_Off = 0, // zgaszone
-    ls_On = 1, // zapalone
-    ls_Blink = 2, // migające
-    ls_Dark = 3, // Ra: zapalajce się automatycznie, gdy zrobi się ciemno
-    ls_Home = 4 // like ls_dark but off late at night
+enum TLightState
+{
+	ls_Off = 0, // zgaszone
+	ls_On = 1, // zapalone
+	ls_Blink = 2, // migające
+	ls_Dark = 3, // Ra: zapalajce się automatycznie, gdy zrobi się ciemno
+	ls_Home = 4, // like ls_dark but off late at night
+	ls_winter = 5 // turned on when its winter
 };
 
 class TAnimVocaloidFrame
@@ -122,6 +124,7 @@ public:
     int TerrainCount();
     TSubModel * TerrainSquare(int n);
     int Flags();
+	void on_season_update();
     inline
     material_data const *
         Material() const {
@@ -171,6 +174,10 @@ private:
     int iNumLights { 0 };
     std::array<TSubModel *, iMaxNumLights> LightsOn {}; // Ra: te wskaźniki powinny być w ramach TModel3d
     std::array<TSubModel *, iMaxNumLights> LightsOff {};
+	TSubModel *sm_winter_variant {}; // submodel zimowego wariantu
+	TSubModel *sm_spring_variant {}; // submodel wiosennego wariantu
+	TSubModel *sm_summer_variant {}; // submodel letniego wariantu
+	TSubModel *sm_autumn_variant {}; // submodel jesiennego wariantu
     std::array<float, iMaxNumLights> lsLights {}; // ls_Off
     std::array<glm::vec3, iMaxNumLights> m_lightcolors; // -1 in constructor
     std::array<float, iMaxNumLights> m_lighttimers {};


### PR DESCRIPTION
We have new tags in submodels:
- winter_variant
- spring_variant
- summer_variant
- autumn_variant

Everything outside these submodels is common for all seasons.