### PR TITLE
Floating point export fix for models

### DIFF
--- a/AnimModel.cpp
+++ b/AnimModel.cpp
@@ -656,9 +656,9 @@ TAnimModel::export_as_text_( std::ostream &Output ) const {
     // header
     Output << "model ";
     // location and rotation
-    Output
-        << location().x << ' '
-        << location().y << ' '
+	Output << std::fixed << std::setprecision(3) // ustawienie dokładnie 3 cyfr po przecinku
+	    << location().x << ' ' 
+        << location().y << ' ' 
         << location().z << ' ';
     Output
        << "0 " ;

--- a/scenenode.h
+++ b/scenenode.h
@@ -47,8 +47,7 @@ operator!=( lighting_data const &Left, lighting_data const &Right ) {
 namespace scene {
 
 struct bounding_area {
-
-    glm::dvec3 center; // mid point of the rectangle
+    glm::highp_dvec3 center; // mid point of the rectangle
     float radius { -1.0f }; // radius of the bounding sphere
 
     bounding_area() = default;
@@ -94,7 +93,7 @@ public:
         material_handle material { null_handle };
         lighting_data lighting;
         // geometry data
-        glm::dvec3 origin; // world position of the relative coordinate system origin
+        glm::highp_dvec3 origin; // world position of the relative coordinate system origin
         gfx::geometry_handle geometry { 0, 0 }; // relative origin-centered chunk of geometry held by gfx renderer
         std::vector<world_vertex> vertices; // world space source data of the geometry
 		gfx::userdata_array userdata;


### PR DESCRIPTION
teraz eksportuje 3 miejsca po przecinku a nie ze ogranicza sie do 6 cyferek niezaleznie od miejsca przecinka