### PR TITLE
Poprawki po 078470c, 2a5d8cc i 7cac46d

### DIFF
--- a/McZapkie/Mover.cpp
+++ b/McZapkie/Mover.cpp
@@ -11343,7 +11343,7 @@ void TMoverParameters::LoadFIZ_PowerParamsDecode( TPowerParameters &Powerparamet
 		    extract_value(PantType, "PantType", Line, "");
             if (PantType == "AKP_4E")
 			    collectorparameters.PantographType = TPantType::AKP_4E;
-		    if (PantType._Starts_with("DSA")) // zakladam ze wszystkie pantografy DSA sa takie same
+		    if (PantType.rfind("DSA",0) == 0) // zakladam ze wszystkie pantografy DSA sa takie same
 			    collectorparameters.PantographType = TPantType::DSAx;
 		    if (PantType == "EC160" || PantType == "EC200")
 			    collectorparameters.PantographType = TPantType::EC160_200;

--- a/application.h
+++ b/application.h
@@ -38,7 +38,7 @@ public:
         run();
     // issues request for a worker thread to perform specified task. returns: true if task was scheduled
 
-    void eu07_application::DiscordRPCService(); // discord rich presence service function (runs as separate thread)
+    void DiscordRPCService(); // discord rich presence service function (runs as separate thread)
     bool
         request( python_taskqueue::task_request const &Task );
     // ensures the main thread holds the python gil and can safely execute python calls

--- a/particles.cpp
+++ b/particles.cpp
@@ -474,7 +474,8 @@ particle_manager::find( std::string const &Template ) {
     }
     // ... and if it fails try to add the template to the database from a data file
     smoke_source source;
-    if( source.deserialize( cParser( templatepath + templatename + ".txt", cParser::buffer_FILE ) ) ) {
+    cParser sound_parser( templatepath + templatename + ".txt", cParser::buffer_FILE );
+    if( source.deserialize( sound_parser ) ) {
         // if deserialization didn't fail finish source setup...
         source.m_opacitymodifier.bind( &Global.SmokeFidelity );
         // ...then cache the source as template for future instances


### PR DESCRIPTION
Dotyczy GCC (078470c):
```
/home/debian/autobuilder/output/build/maszyna/application.h:41:10: error: extra qualification ‘eu07_application::’ on member ‘DiscordRPCService’ [-fpermissive]
   41 |     void eu07_application::DiscordRPCService(); // discord rich presence service function (runs as separate thread)
      |          ^~~~~~~~~~~~~~~~
```
\
C++20 tylko do jednej funkcji jest nieprzydatne (2a5d8cc):
```
/home/debian/autobuilder/output/build/maszyna/McZapkie/Mover.cpp:11346:34: error: ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} has no member named ‘_Starts_with’
11346 |                     if (PantType._Starts_with("DSA")) // zakladam ze wszystkie pantografy DSA sa takie same
      |                                  ^~~~~~~~~~~~
```
\
Absurd z 7cac46d:
```
/home/debian/autobuilder/output/build/maszyna/particles.cpp:477:29: error: cannot bind non-const lvalue reference of type ‘cParser&’ to an rvalue of type ‘cParser’
  477 |     if( source.deserialize( cParser( templatepath + templatename + ".txt", cParser::buffer_FILE ) ) ) {
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```